### PR TITLE
Wagtail 5.1 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add upgrade considerations for Wagtail 5.1
+
 ## 1.0.0 (2023-07-25)
 
 - Integrate [wagtail upgrades](https://github.com/unexceptable/wagtail-robots/pull/20)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,7 +37,7 @@ Or get the source from the application site at::
 
 Then follow these steps:
 
-1. Add ``'wagtail.contrib.modeladmin'`` and ``'robots'`` to your INSTALLED_APPS_ setting.
+1. Add ``'wagtail_modeladmin'`` (if the Wagtail version is 5.1 and above, otherwise ``'wagtail.contrib.modeladmin'``) and ``'robots'`` to your INSTALLED_APPS_ setting.
 2. Run the ``migrate`` management command
 
 You may want to additionally setup the `Wagtail sitemap generator`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ Installation
 Use your favorite Python installer to install it from PyPI::
 
    pip install wagtail-robots
+   pip install wagtail_modeladmin  # if Wagtail >= 5.1
 
 Or get the source from the application site at::
 
@@ -37,7 +38,15 @@ Or get the source from the application site at::
 
 Then follow these steps:
 
-1. Add ``'wagtail_modeladmin'`` (if the Wagtail version is 5.1 and above, otherwise ``'wagtail.contrib.modeladmin'``) and ``'robots'`` to your INSTALLED_APPS_ setting.
+1. Add ``robots`` and ``modeladmin`` to the ``INSTALLED_APPS`` setting in your project settings::
+
+      INSTALLED_APPS = [
+         ...
+         'wagtail_modeladmin',          # if Wagtail >=5.1; Don't repeat if it's there already
+         'wagtail.contrib.modeladmin',  # if Wagtail <5.1;  Don't repeat if it's there already
+         'robots',
+      ]
+
 2. Run the ``migrate`` management command
 
 You may want to additionally setup the `Wagtail sitemap generator`_.

--- a/robots/test/settings.py
+++ b/robots/test/settings.py
@@ -127,8 +127,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/robots/test/settings.py
+++ b/robots/test/settings.py
@@ -10,6 +10,8 @@ https://docs.djangoproject.com/en/stable/ref/settings/
 
 import os
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
 # Build paths inside the project like this: os.path.join(PROJECT_DIR, ...)
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
@@ -42,7 +44,7 @@ INSTALLED_APPS = [
     "wagtail.search",
     "wagtail.admin",
     "wagtail.api.v2",
-    "wagtail.contrib.modeladmin",
+    "wagtail_modeladmin" if WAGTAIL_VERSION >= (5, 1) else "wagtail.contrib.modeladmin",
     "wagtail.contrib.routable_page",
     "wagtail.contrib.styleguide",
     "wagtail.sites",

--- a/robots/wagtail_hooks.py
+++ b/robots/wagtail_hooks.py
@@ -1,5 +1,10 @@
 
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail import VERSION as WAGTAIL_VERSION
+
+if WAGTAIL_VERSION >= (5, 1):
+    from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
+else:
+    from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 
 from robots.models import Rule
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,12 @@ setup(
     },
     install_requires=[
         'wagtail>=4.1',
-        'wagtail_modeladmin>=1.0',
     ],
+    extras_require={
+        'testing': [
+            'wagtail-modeladmin>=1.0',
+        ],
+    },
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     },
     install_requires=[
         'wagtail>=4.1',
+        'wagtail_modeladmin>=1.0',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,3 @@ flake8>=3.0.4
 sphinx!=1.6.1,>=1.5.1
 sphinx-rtd-theme>=0.2.4
 doc8
-wagtail_modeladmin>=1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ flake8>=3.0.4
 sphinx!=1.6.1,>=1.5.1
 sphinx-rtd-theme>=0.2.4
 doc8
+wagtail_modeladmin>=1.0

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist = 
-    py{38,39,310}-dj{32,41,42}-wt{41,42,50}
-    py{311}-dj{41,42}-wt{41,42,50}
+    py{38,39,310}-dj{32,41}-wt{41,42,50,51}
+    py311-dj41-wt{41,42,50,51}
+    py311-dj42-wt{50,51}
 
 [gh-actions]
 python =


### PR DESCRIPTION
[Wagtail 5.1 release notes](https://docs.wagtail.org/en/stable/releases/5.1.html)

### Upgrade considerations applied:
- [wagtail.contrib.modeladmin is deprecated](https://docs.wagtail.org/en/stable/releases/5.1.html#wagtail-contrib-modeladmin-is-deprecated)