### PR TITLE
Wagtail 7.0 maintenance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,10 @@ setup(
         'Programming Language :: Python :: 3.13',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.1',
+        'Framework :: Django :: 5.2',
         'Framework :: Wagtail :: 5',
         'Framework :: Wagtail :: 6',
+        'Framework :: Wagtail :: 7',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,8 @@ usedevelop = True
 skip_missing_interpreters = True
 
 envlist = 
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.3,6.4}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.3,6.4}
-    python{3.12,3.13}-django5.1-wagtail{6.3,6.4}
+    python{3.9,3.10,3.11,3.12}-django4.2-wagtail{5.2,6.3,6.4,7.0}
+    python{3.10,3.11,3.12,3.13}-django{5.1,5.2}-wagtail{6.3,6.4,7.0}
 
 [gh-actions]
 python =
@@ -19,15 +18,15 @@ python =
 [testenv]
 deps =
     django4.2: Django>=4.2,<4.3
-    django5.0: Django>=5.0,<5.1
     django5.1: Django>=5.1,<5.2
+    django5.2: Django>=5.2,<5.3
 
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1
 
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11


### PR DESCRIPTION
The key changes involve adding compatibility with Django 5.2 and Wagtail 7.0.

### Framework compatibility updates:
* Added support for Django 5.2, and Wagtail 7.0 in the list of supported frameworks.

### Testing matrix updates:
* Added dependency definitions for Django 5.2 and Wagtail 7.0, while removing the unused Python 3.8 base environment.
* Drop testing for Django 5.0